### PR TITLE
init: display warnings when cross-assembling system-images

### DIFF
--- a/roles/common/tasks/init.yaml
+++ b/roles/common/tasks/init.yaml
@@ -18,6 +18,20 @@
   ignore_errors: true
   register: results
 
+- name: Warn for cross-arch assembly
+  ansible.builtin.debug:
+    msg:
+      - "Warning! You're assembling aarch64 system images on an x86_64 host."
+      - "Emulation will be used and the process will be very slow!"
+  when: target_arch == "aarch64" and ansible_architecture == "x86_64"
+
+- name: Warn for unsupported cross-arch assembly
+  ansible.builtin.debug:
+    msg:
+      - "Warning! You're attempting to assemble x86_64 system images on an aarch64 host."
+      - "This is not supported yet!"
+  when: target_arch == "x86_64" and ansible_architecture == "aarch64"
+
 - name: Prepare output directory
   ansible.builtin.file:
     path: "./out"


### PR DESCRIPTION
Add some tasks to the init role to display warnings when doing cross-assembly of system-images (that invoke emulation and cause slow execution).

Explicitly warn when building x86_64 images on aarch64 hosts because this is not supported yet (no pre-made osbuildvm-images available yet).