### PR TITLE
prepare-osbuild: allow pinning of osbuild rpms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,14 +1,35 @@
-# Basic configuration
+# == Basic configuration ==
+
 target_image: cs9-qemu-minimal-regular
 target_arch: aarch64
 target_filetype: qcow2
 
-# Advanced configuration
+# == Advanced configuration ==
+
+# osbuild_vmimages_download_baseurl directs where to fetch osbuildvm-images from
+# This is used for cross-arch assembly (building aarch64 images on x86_64 hosts)
 osbuild_vmimages_download_baseurl: "https://autosd.sig.centos.org/AutoSD-9/nightly/osbuildvm-images"
+
+# osbuild_packages can be used to pin specific versions of osbuild by setting the value param
+# eg. value: "osbuild-84-1.20230505134457921609.main.12.gdfcd847.el9"
+# leaving the value equal to the name will enable using the latest versions by default
+osbuild_packages:
+  - package: "osbuild"
+    value: "osbuild"
+  - package: "osbuild-tools"
+    value: "osbuild-tools"
+  - package: "osbuild-ostree"
+    value: "osbuild-ostree"
+  - package: "osbuildtest-ostree-compliance-mode"
+    value: "osbuildtest-ostree-compliance-mode"
+
+# git reference for sample-images project (you can change sample_images_git_ref to pin the version)
 sample_images_git_url: "https://gitlab.com/CentOS/automotive/sample-images.git"
 sample_images_git_ref: "main"
+
+# local path to clone sample-images into
 sample_images_path: "{{ ansible_env.HOME }}/sample-images"
-sample_images_build_path: "{{ ansible_env.HOME }}/sample-images/osbuild-manifests/_build"
+sample_images_build_path: "{{ sample_images_path }}/osbuild-manifests/_build"
 
 # Hetzner Cloud configuration
 hcloud_aarch64_server_type: "cax21"

--- a/roles/common/tasks/init.yaml
+++ b/roles/common/tasks/init.yaml
@@ -11,6 +11,7 @@
     echo "target_filetype: {{ target_filetype }}"
     echo "# Advanced Configuration"
     echo "osbuild_vmimages_download_baseurl: {{ osbuild_vmimages_download_baseurl }}"
+    echo "osbuild_packages: {{ osbuild_packages }}"
     echo "sample_images_git_url: {{ sample_images_git_url }}"
     echo "sample_images_git_ref: {{ sample_images_git_ref }}"
     echo "sample_images_path: {{ sample_images_path }}"

--- a/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
+++ b/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
@@ -51,17 +51,22 @@
   ignore_errors: true
   register: results_copr_abootimg
 
-- name: Install dependencies
-  become: yes
-  ansible.builtin.dnf:
-    name:
+- name: Calculating dependencies
+  set_fact:
+    osbuild_dependencies:
       - abootimg
       - aboot-update
       - make
-      - osbuild
-      - osbuild-tools
-      - osbuild-ostree
-      - osbuildtest-ostree-compliance-mode
+      - "{{ osbuild_packages | selectattr('package', 'match', 'osbuild') | map(attribute='value') | first }}"
+      - "{{ osbuild_packages | selectattr('package', 'match', 'osbuild-tools') | map(attribute='value') | first }}"
+      - "{{ osbuild_packages | selectattr('package', 'match', 'osbuild-ostree') | map(attribute='value') | first }}"
+      - "{{ osbuild_packages | selectattr('package', 'match', 'osbuildtest-ostree-compliance-mode') | map(attribute='value') | first }}"
+
+- name: Install dependencies
+  become: yes
+  ansible.builtin.dnf:
+    allow_downgrade: true
+    name: "{{ osbuild_dependencies }}"
   ignore_errors: true
   register: results_install_deps
 
@@ -105,6 +110,11 @@
       Enabling Copr: alexl/abootimg
       =============================
       {{ results_copr_abootimg }}
+
+      Calculating dependencies
+      ========================
+      osbuild_dependencies:
+        "{{ osbuild_dependencies }}"
 
       Installing dependencies
       =======================


### PR DESCRIPTION
Modify config.yaml to have a list of osbuild rpms (under the name osbuild_packages) that can be pinned and in addition add some comments into the yaml file to improve the documentation.

The prepare-osbuild role is modified to take into account the new config variable (osbuild_packages).