### PR TITLE
clone-custom-images: add new task to playbooks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,10 @@ target_image: cs9-qemu-minimal-regular
 target_arch: aarch64
 target_filetype: qcow2
 
+custom_images_git_url: "https://gitlab.com/redhat/edge/ci-cd/pipe-x/custom-images.git"
+custom_images_git_ref: "main"
+custom_images_path: "{{ ansible_env.HOME }}/custom-images"
+
 # == Advanced configuration ==
 
 # osbuild_vmimages_download_baseurl directs where to fetch osbuildvm-images from

--- a/hetzner-cloud.yaml
+++ b/hetzner-cloud.yaml
@@ -16,6 +16,12 @@
   roles:
     - clone-sample-images
 
+- name: clone custom images
+  hosts: my-server
+  remote_user: root
+  roles:
+    - clone-custom-images
+
 - name: prepare osbuild
   hosts: my-server
   remote_user: root

--- a/local.yaml
+++ b/local.yaml
@@ -9,6 +9,11 @@
   roles:
     - clone-sample-images
 
+- name: clone custom images
+  hosts: localhost
+  roles:
+    - clone-custom-images
+
 - name: prepare osbuild
   hosts: localhost
   roles:

--- a/roles/clone-custom-images/tasks/clone_custom_images.yaml
+++ b/roles/clone-custom-images/tasks/clone_custom_images.yaml
@@ -1,0 +1,29 @@
+---
+- name: Install git
+  ansible.builtin.package:
+    name: git
+    state: present
+  become: yes
+
+- name: Clone custom-images project
+  ansible.builtin.git:
+    repo: "{{ custom_images_git_url }}"
+    dest: "{{ custom_images_path }}"
+    version: "{{ custom_images_git_ref }}"
+  ignore_errors: true
+  register: results
+  when: custom_images_git_url is defined
+
+- name: Write log files
+  copy:
+    content: "{{ results }}"
+    dest: "./out/log.clone_custom_images.txt"
+  delegate_to: localhost
+  when: custom_images_git_url is defined
+
+- name: Error handler
+  debug:
+    var: results
+  failed_when: true
+  when:
+    custom_images_git_url is defined and results is failed

--- a/roles/clone-custom-images/tasks/main.yaml
+++ b/roles/clone-custom-images/tasks/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: load variables
+  ansible.builtin.include_vars: ../../../config.yaml
+
+- include_tasks: clone_custom_images.yaml

--- a/roles/run-make/tasks/run_make.yaml
+++ b/roles/run-make/tasks/run_make.yaml
@@ -1,14 +1,25 @@
 ---
+- name: decide make params
+  set_fact:
+    run_make_params:
+      IMAGEDIR: "{{ custom_images_path if custom_images_path is defined else '' }}"
+
 - name: run make
   become: yes
   make:
-    chdir: "{{ ansible_env.HOME }}/sample-images/osbuild-manifests"
+    chdir: "{{ sample_images_path }}/osbuild-manifests"
     target: "{{ target_image }}.{{ target_arch }}.{{ target_filetype }}"
+    params: "{{ run_make_params|dict2items|rejectattr('value', 'equalto', '')|list|items2dict }}"
+  ignore_errors: true
   register: results
 
 - name: Write log files
   copy:
-    content: "{{ results.stdout }}"
+    content: |
+      chdir: {{ sample_images_path }}/osbuild-manifests
+      target: {{ target_image }}.{{ target_arch }}.{{ target_filetype }}
+      params: {{ run_make_params|dict2items|rejectattr('value', 'equalto', '')|list|items2dict }}
+      {{ results.stdout }}
     dest: "./out/log.run_make.txt"
   delegate_to: localhost
 


### PR DESCRIPTION
Add task to clone a custom-images project to extend the sample-images project with custom system-image mpp files. Also adjusts the run_make playbook to set the IMAGEDIR Makefile params needed to use it.