### PR TITLE
prepare-osbuild: add support for rhel9 build hosts

### DIFF
--- a/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
+++ b/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
@@ -23,6 +23,7 @@
   community.general.copr:
     state: enabled
     name: '@osbuild/osbuild'
+    chroot: "{{ 'epel-9-'+ansible_architecture if ansible_distribution == 'RedHat' else omit }}"
   ignore_errors: true
   register: results_copr_osbuild
 
@@ -31,6 +32,7 @@
   community.general.copr:
     state: enabled
     name: 'ecurtin/osbuildtest-ostree-compliance-mode'
+    chroot: "{{ 'epel-9-'+ansible_architecture if ansible_distribution == 'RedHat' else omit }}"
   ignore_errors: true
   register: results_copr_ostree_compliance_mode
 
@@ -39,6 +41,7 @@
   community.general.copr:
     state: enabled
     name: 'alexl/osbuild-aboot'
+    chroot: "{{ 'epel-9-'+ansible_architecture if ansible_distribution == 'RedHat' else omit }}"
   ignore_errors: true
   register: results_copr_osbuild_aboot
 


### PR DESCRIPTION
Not all of the copr repositories have builds for all supported distros. Add some conditional statements to fallback on epel-9 chroot if a rhel host is detected to make a best attempt at installation.

The osbuild copr seems to select the centos stream 8 chroot on rhel9 so this commit adds a conditional to force epel-9 to fix that.