### PR TITLE
docs: break up README.md into multiple parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automotive-SIG Zeppelin - Take your automotive-sig builds to the clouds
 
 ## About
 
-Zeppelin is a meta build system for the [Automotive-SIG sample-images][0]
+Zeppelin is a meta build system for the [Automotive-SIG sample-images][1]
 project with the goal being to enable building customised AutoSD system images
 using the cloud.
 
@@ -15,7 +15,7 @@ aarch64 system images without emulation for only a few cents per build!
 
 ## Background
 
-The [CentOS Automotive-SIG project][1] provides a Makefile-based build system to
+The [CentOS Automotive-SIG project][3] provides a Makefile-based build system to
 assemble system-images (with OSBuild). This build system supports configuration
 via both command line parameters and custom yaml snippet files that extend /
 overwrite the default image configuration.
@@ -47,13 +47,17 @@ The build host and system-image target build configuration is defined in
 `config.yaml`. This yaml file is loaded by the different roles to dynamically
 configure them at runtime.
 
-The system image build target is configured with the variables:
+A deep dive in the `config.yaml` can be found in:
+[docs/config.md](docs/config.md).
+
+The minimal config to get started are the three following variables which
+configure the system image build target:
 
 - target_image
 - target_arch
 - target_filetype
 
-These variables align with the [Automotive-SIG Makefile targets][1] so you can
+These variables align with the [Automotive-SIG Makefile targets][3] so you can
 refer to their documentation for details.
 
 In the future there will be a simple `configure.sh` to help generate this
@@ -62,119 +66,30 @@ configuration yaml.
 ## Requirements
 
 Since Zeppelin is based on Ansible, you must have it installed on the computer
-that starts the build process (aka your personal computer). You can find out
-more [here][3] on how to install it.
+that starts the build process (aka your personal computer). Typically you can
+install Ansible with pip.
+
+```
+python3 -m pip install --user ansible
+```
+
+You can find out more [here][4] on how to install it.
 
 In addition to having installed ansible, you need the [community.general
-Ansible collection][9] installed also.
+Ansible collection][5] installed also.
 
 ```
 ansible-galaxy collection install community.general
 ```
 
-## Running Builds Locally
+## Usage
 
-Zeppelin can orchestrate the build operations on the local computer that runs
-Ansible. Local builds are supported given the host machine is one of the
-supported distros:
+Zeppelin supports a variety of use cases and configuration/instructons differ
+for each. Details for each use case can be found in the linked documents.
 
-- Fedora 37
-
-You can run a local build by invoking `ansible-playbook` on the `local.yaml`
-playbook with the `-K` parameter.
-
-```
-ansible-playbook local.yaml -K
-```
-
-The `-K` parameter is needed because sudo/root privileges are needed to run
-OSBuild.
-
-> :warning: If the builder cpu architecture is x86_64 and an aarch64 system
-> image is configured as the build target, qemu will be used automatically to
-> wrap the build process (see [Building in a virtual machine][4]) but this
-> will be very slow to complete.
-
-The results of the build (on success) can be found in the `out` directory
-(created in the current working directory). See the [Outputs section below](#Output-Directory)
-for more details on the output contents.
-
-## Running Builds on Hetzner Cloud
-
-Zeppelin can orchestrate spawning a cloud server instance on Hetzner Cloud,
-running the build operations on said server, fetching the results back to the
-users computer, and deleting the cloud server as a final clean up operation.
-
-> :warning: Be warned! If the build fails or is cancelled midway through, the
-> server instance is not automatically cleaned up! Later I intend to add a
-> playbook to help do manual clean ups but until then you should keep an eye on
-> the usage billing of your account to avoid any nasty surprises.
-
-To build with Hetzner Cloud, [you need an existing account][1] and you need to
-[generate an API key][3] and [add it as the shell environment variable][5]:
-`HCLOUD_TOKEN`.
-
-```
-export HCLOUD_TOKEN=abc123
-```
-
-In addition to having [Ansible installed][2], you must also install the [hcloud
-pypi package][6] and the [hetzner.hcloud Ansible module][7]. This enables the
-playbooks to interact with the Hetzner Cloud API.
-
-```
-pip install hcloud
-ansible-galaxy collection install hetzner.hcloud
-```
-
-You can run a build with Hetzner cloud by invoking `ansible-playbook` on the
-`hetzner-cloud.yaml` playbook with the hetzner-cloud inventory.
-
-```
-ansible-playbook -i inventories/hetzner-cloud/hcloud.yaml hetzner-cloud.yaml
-```
-
-The results of the build (on success) can be found in the `out` directory
-(created in the current working directory). See the [Outputs section](#Output-Directory)
-below for more details on the output contents.
-
-## Running Builds with Virtual Machines (By Abusing tmt)
-
-We can abuse [tmt (test management tool)][8] to run Zeppelin in a virtual
-machine (locally). tmt is a testing framework tool that runs tests in an
-ansible-style workflow and has inbuilt provisioning mechanisms to spawn said
-test plans in containers, virtual machines or locally with no wrapper.
-
-Zeppelin takes advantage of this by having a tmt test plan (see:
-`./tmt/zeppelin.fmf`) that simply executes Zeppelin and extracts the resulting
-output files back to the host operating system.
-
-You can run the tmt test plan locally by calling `tmt run`.
-
-```
-tmt run -vvvv
-```
-
-Using -vvvv as a parameter enables an excessive logging level which provides
-live logs of the Zeppelin process.
-
-The output will not be stored in the `out` directory like the other execution
-methods did so far. When tmt is executed, the first line it prints will show
-its working directory (eg. `/var/tmp/tmt/run-001`) and it's under this directory
-where the output data will end up.
-
-Example:
-
-```
-$ ls -al /var/tmp/tmt/run-001/tmt/zeppelin/data/out
-total 242208
--rw-r--r--. 1 michael michael    128911 May  4 16:47 cs9-qemu-minimal-regular.x86_64.json
--rw-r--r--. 1 michael michael 247791616 May  4 16:47 cs9-qemu-minimal-regular.x86_64.qcow2
--rw-r--r--. 1 michael michael       103 May  4 16:47 log.clone_sample_images.txt
--rw-r--r--. 1 michael michael       501 May  4 16:47 log.init.txt
--rw-r--r--. 1 michael michael      4407 May  4 16:47 log.prepare_osbuild.txt
--rw-r--r--. 1 michael michael     79027 May  4 16:47 log.run_make.txt
-```
+- [Running builds locally](docs/building-locally.md)
+- [Running builds on Hetzner Cloud](docs/building-with-hetzner-cloud.md)
+- [Running builds with tmt](docs/building-with-tmt.md)
 
 ## Output Directory
 
@@ -193,13 +108,8 @@ scripts may be added to the resulting directory.
 > :warning: The output directory is not cleaned automatically between runs of
 > the playbooks so you must manually do so.
 
-[0]: https://sigs.centos.org/automotive/
-[1]: https://sigs.centos.org/automotive/building/#using-makefile-to-build-the-image
+[1]: https://sigs.centos.org/automotive/
 [2]: https://www.hetzner.com/cloud
-[3]: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible
-[4]: https://sigs.centos.org/automotive/building/#building-in-a-virtual-machine
-[5]: https://unix.stackexchange.com/questions/117467/how-to-permanently-set-environmental-variables
-[6]: https://pypi.org/project/hcloud/
-[7]: https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/index.html
-[8]: https://tmt.readthedocs.io/en/stable/overview.html
-[9]: https://galaxy.ansible.com/community/general
+[3]: https://sigs.centos.org/automotive/building/#using-makefile-to-build-the-image
+[4]: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible
+[5]: https://galaxy.ansible.com/community/general

--- a/config.yaml
+++ b/config.yaml
@@ -1,22 +1,18 @@
+# See docs/config.md for documentation on the different parameters in this file
+
 # == Basic configuration ==
 
-target_image: cs9-qemu-minimal-regular
-target_arch: aarch64
-target_filetype: qcow2
+target_image: cs9-qemu-qa-ostree
+target_arch: x86_64
+target_filetype: img
 
 custom_images_git_url: "https://gitlab.com/redhat/edge/ci-cd/pipe-x/custom-images.git"
 custom_images_git_ref: "main"
 custom_images_path: "{{ ansible_env.HOME }}/custom-images"
 
 # == Advanced configuration ==
-
-# osbuild_vmimages_download_baseurl directs where to fetch osbuildvm-images from
-# This is used for cross-arch assembly (building aarch64 images on x86_64 hosts)
 osbuild_vmimages_download_baseurl: "https://autosd.sig.centos.org/AutoSD-9/nightly/osbuildvm-images"
 
-# osbuild_packages can be used to pin specific versions of osbuild by setting the value param
-# eg. value: "osbuild-84-1.20230505134457921609.main.12.gdfcd847.el9"
-# leaving the value equal to the name will enable using the latest versions by default
 osbuild_packages:
   - package: "osbuild"
     value: "osbuild"
@@ -27,11 +23,8 @@ osbuild_packages:
   - package: "osbuildtest-ostree-compliance-mode"
     value: "osbuildtest-ostree-compliance-mode"
 
-# git reference for sample-images project (you can change sample_images_git_ref to pin the version)
 sample_images_git_url: "https://gitlab.com/CentOS/automotive/sample-images.git"
 sample_images_git_ref: "main"
-
-# local path to clone sample-images into
 sample_images_path: "{{ ansible_env.HOME }}/sample-images"
 sample_images_build_path: "{{ sample_images_path }}/osbuild-manifests/_build"
 

--- a/docs/building-locally.md
+++ b/docs/building-locally.md
@@ -1,0 +1,33 @@
+# Running Builds Locally
+
+Zeppelin can orchestrate the build operations on the local computer that runs
+Ansible. Local builds are supported given the host machine is one of the
+supported distros:
+
+- Fedora 37
+- Fedora 38
+- CentOS Stream 9
+- Red Hat Enterprise Linux 9
+
+# Usage
+
+You can run a local build by invoking `ansible-playbook` on the `local.yaml`
+playbook with the `-K` parameter.
+
+```
+ansible-playbook local.yaml -K
+```
+
+The `-K` parameter is needed because sudo/root privileges are needed to run
+OSBuild.
+
+> :warning: If the builder cpu architecture is x86_64 and an aarch64 system
+> image is configured as the build target, qemu will be used automatically to
+> wrap the build process (see [Building in a virtual machine][1]) but this
+> will be very slow to complete.
+
+The results of the build (on success) can be found in the `out` directory
+(created in the current working directory). See the [Outputs section below](#Output-Directory)
+for more details on the output contents.
+
+[1]: https://sigs.centos.org/automotive/building/#building-in-a-virtual-machine

--- a/docs/building-with-hetzner-cloud.md
+++ b/docs/building-with-hetzner-cloud.md
@@ -1,0 +1,71 @@
+# Running Builds on Hetzner Cloud
+
+Zeppelin can orchestrate spawning a cloud server instance on Hetzner Cloud,
+running the build operations on said server, fetching the results back to the
+users computer, and deleting the cloud server as a final clean up operation.
+
+> :warning: Be warned! If the build fails or is cancelled midway through, the
+> server instance is not automatically cleaned up! Later I intend to add a
+> playbook to help do manual clean ups but until then you should keep an eye on
+> the usage billing of your account to avoid any nasty surprises.
+
+## Additional Requirements
+
+To build with Hetzner Cloud, [you need an existing account][1] and you need to
+[generate an API key][2] and [add it to the shell as environment variable][3]:
+`HCLOUD_TOKEN`.
+
+```
+export HCLOUD_TOKEN=abc123
+```
+
+In addition to having [Ansible installed][4], you must also install the [hcloud
+pypi package][5] and the [hetzner.hcloud Ansible module][6]. This enables the
+playbooks to interact with the Hetzner Cloud API.
+
+```
+pip install hcloud
+ansible-galaxy collection install hetzner.hcloud
+```
+
+You also need to have an [ssh key set up in your Hetzner account][7].
+
+## Configuration
+
+You must change the ssh keys mentioned in the config.yaml to match [those you
+set up in your Hetzner account][7]. These keys will be imported to the VMs on
+creation and that will be how Ansible accesses the remote builder.
+
+Example (Where the ssh key is named michael@fedora):
+
+```
+- hcloud_aarch64_ssh_keys
+    - "michael@fedora"
+- hcloud_x86_64_ssh_keys
+    - "michael@fedora"
+```
+
+This should match the keys on the host computer running Ansible.
+
+The other Hetzner Cloud config options are documented in [config.md](/docs/config.md).
+
+## Usage
+
+You can run a build with Hetzner cloud by invoking `ansible-playbook` on the
+`hetzner-cloud.yaml` playbook with the hetzner-cloud inventory.
+
+```
+ansible-playbook -i inventories/hetzner-cloud/hcloud.yaml hetzner-cloud.yaml
+```
+
+The results of the build (on success) can be found in the `out` directory
+(created in the current working directory). See the [Outputs section](#Output-Directory)
+below for more details on the output contents.
+
+[1]: https://www.hetzner.com/cloud
+[2]: https://docs.hetzner.cloud/#getting-started
+[3]: https://unix.stackexchange.com/questions/117467/how-to-permanently-set-environmental-variables
+[4]: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible
+[5]: https://pypi.org/project/hcloud/
+[6]: https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/index.html
+[7]: https://community.hetzner.com/tutorials/add-ssh-key-to-your-hetzner-cloud

--- a/docs/building-with-tmt.md
+++ b/docs/building-with-tmt.md
@@ -1,0 +1,46 @@
+# Running Builds with tmt
+
+We can abuse [tmt (test management tool)][1] to run Zeppelin in a virtual
+machine (locally). tmt is a testing framework tool that runs tests in an
+ansible-style workflow and has inbuilt provisioning mechanisms to spawn said
+test plans in containers, virtual machines or locally with no wrapper.
+
+Zeppelin takes advantage of this by having a tmt test plan (see:
+`./tmt/zeppelin.fmf`) that simply executes Zeppelin and extracts the resulting
+output files back to the host operating system.
+
+## Additional Requirements
+
+To build with tmt, you need tmt installed on the local system in addition to
+the base requirements (Ansible).
+
+## Usage
+
+You can run the tmt test plan locally by calling `tmt run`.
+
+```
+tmt run -vvvv
+```
+
+Using -vvvv as a parameter enables an excessive logging level which provides
+live logs of the Zeppelin process.
+
+The output will not be stored in the `out` directory like the other execution
+methods did so far. When tmt is executed, the first line it prints will show
+its working directory (eg. `/var/tmp/tmt/run-001`) and it's under this directory
+where the output data will end up.
+
+Example:
+
+```
+$ ls -al /var/tmp/tmt/run-001/tmt/zeppelin/data/out
+total 242208
+-rw-r--r--. 1 michael michael    128911 May  4 16:47 cs9-qemu-minimal-regular.x86_64.json
+-rw-r--r--. 1 michael michael 247791616 May  4 16:47 cs9-qemu-minimal-regular.x86_64.qcow2
+-rw-r--r--. 1 michael michael       103 May  4 16:47 log.clone_sample_images.txt
+-rw-r--r--. 1 michael michael       501 May  4 16:47 log.init.txt
+-rw-r--r--. 1 michael michael      4407 May  4 16:47 log.prepare_osbuild.txt
+-rw-r--r--. 1 michael michael     79027 May  4 16:47 log.run_make.txt
+```
+
+[1]: https://tmt.readthedocs.io/en/stable/overview.html

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,167 @@
+# Configuration YAML
+
+Zeppelin is configured via a config.yaml file in the base directory. The file
+is split into two sections, basic and advanced configuration. Typically you
+only want to modify the basic section to begin building and you only need to
+modify the advanced configuration to tune the build process.
+
+This document explains the different configuration tuning variables in the
+config.yaml.
+
+# Link to Automotive-SIG sample-images Makefile
+
+Many of the configuration parameters are based around the configuration of the
+Makefile in the sample-images project. You should read [this doc][1] as
+preliminary reading before trying to understand how to configure Zeppelin.
+
+You can also find more info by running `make help` with the [Automotive-SIG
+sample-images Makefile][2].
+
+[1]: https://sigs.centos.org/automotive/building/#using-makefile-to-build-the-image
+[2]: https://gitlab.com/CentOS/automotive/sample-images/-/blob/main/osbuild-manifests/Makefile
+
+# Basic Configuration
+
+- `target_image`
+
+  Specifies the target image to assemble with the sample-images Makefile. This
+  aligns to the first part of the Makefile target when using the Makefile
+  directly.
+
+  eg. `cs9-qemu-minimal-ostree`
+
+- `target_arch`
+
+  Specifies the architecture of the target image to assemble. This aligns to
+  the second part of the Makefile target when using the Makefile directly.
+
+  i.e. `x86_64` or `aarch64`
+
+- `target_filetype`
+
+  Specifies the output image file type. This aligns to the third part of the
+  Makefile target when using the Makefile directly.
+
+  eg. qcow2
+
+- `custom_images_git_url`
+
+  Optionally specifies a secondary git repository to clone into the host system
+  to use with the Makefile parameter, `IMAGEDIR`. This allows for extending the
+  Makefile targets with custom images beyond those defined in the sample-images
+  project.
+
+  eg. <https://gitlab.com/redhat/edge/ci-cd/pipe-x/custom-images.git>
+
+- `custom_images_git_ref`
+
+  Specifies the git reference to use when cloning `custom_images_git_url`.
+
+  eg. `main`
+
+- `custom_images_path`
+
+  Specifies the local path to clone `custom_images_git_url` into.
+
+  eg. `{{ ansible_env.HOME }}/custom-images`
+
+# Advanced Configuration
+
+These configuration parameters are configured with sane defaults to get started
+with running Zeppelin. You should only modify these values when intending to
+force Zeppelin to build with custom resources such as a fork of the
+Automotive-SIG sample-images project.
+
+- `osbuild_vmimages_download_baseurl`
+
+  This parameter directs where Zeppelin should download the osbuildvm-images
+  from. This is needed for cross-arch assembly (eg. building aarch64 images on
+  x86_64 hosts).
+
+  More information about osbuild-vmimages can be found [here][3].
+
+- `osbuild_packages`
+
+  This parameter contains a mapping of osbuild packages to rpm names/versions.
+  The default values mapped to the package names are the names of the rpms which
+  will make Zeppelin use the latest versions available.
+
+  It can be used to pin specific versions of osbuild by setting the values to
+  &lt;name&gt;-&lt;version&gt; instead of only &lt;name&gt;.
+
+  Example:
+  ```
+  osbuild_packages:
+    - package: "osbuild"
+      value: "osbuild-84-1.20230505134457921609.main.12.gdfcd847.el9"
+    - package: "osbuild-tools"
+      value: "osbuild-tools-84-1.20230505134457921609.main.12.gdfcd847.el9"
+    - package: "osbuild-ostree"
+      value: "osbuild-ostree-84-1.20230505134457921609.main.12.gdfcd847.el9"
+    - package: "osbuildtest-ostree-compliance-mode"
+      value: "osbuildtest-ostree-compliance-mode-84-1.20230505134457921609.main.12.gdfcd847.el9"
+  ```
+
+- `sample_images_git_url`
+
+  Specifies the git url for the sample-images project to clone.
+
+  eg. `https://gitlab.com/CentOS/automotive/sample-images.git`
+
+- `sample_images_git_ref`
+
+  Specifies the git reference to use when cloning `sample_images_git_url`.
+
+  eg. `main`
+
+- `sample_images_path`
+
+  Specifies the local path to clone `sample_images_git_url` into.
+
+  eg. `{{ ansible_env.HOME }}/sample-images`
+
+- `sample_images_build_path`
+
+  Specifies the temporary work directory for the Makefile to use when
+  assemblying the target image. This should typically not be changed as the
+  defaults line up to the standard operation for the Makefile.
+
+  eg. `{{ sample_images_path }}/osbuild-manifests/_build`
+
+[3]: https://sigs.centos.org/automotive/building/#building-in-a-virtual-machine
+
+## Advanced Configration: Hetzner Cloud Configuration
+
+These configuration parameters only apply when using Hetzner Cloud.
+
+- `hcloud_aarch64_server_type`
+
+  To be documented.
+
+- `hcloud_aarch64_image`
+
+  To be documented.
+
+- `hcloud_aarch64_location`
+
+  To be documented.
+
+- `hcloud_aarch64_ssh_keys`
+
+  To be documented.
+
+- `hcloud_x86_64_server_type`
+
+  To be documented.
+
+- `hcloud_x86_64_image`
+
+  To be documented.
+
+- `hcloud_x86_64_location`
+
+  To be documented.
+
+- `hcloud_x86_64_ssh_keys`
+
+  To be documented.


### PR DESCRIPTION
Begin improving docs by breaking the README.md into smaller chunks. Add a config specific doc and separate docs for each build environment.