### PR TITLE
hetzner-cloud.yaml: support parallel builders

### DIFF
--- a/docs/building-with-hetzner-cloud.md
+++ b/docs/building-with-hetzner-cloud.md
@@ -58,6 +58,10 @@ You can run a build with Hetzner cloud by invoking `ansible-playbook` on the
 ansible-playbook -i inventories/hetzner-cloud/hcloud.yaml hetzner-cloud.yaml
 ```
 
+The playbook will create a new server instance with the required architecture
+and configured system image (with a randomised name), run the operations on
+said machine, and delete/clean up the instance on finishing.
+
 The results of the build (on success) can be found in the `out` directory
 (created in the current working directory). See the [Outputs section](#Output-Directory)
 below for more details on the output contents.

--- a/hetzner-cloud.yaml
+++ b/hetzner-cloud.yaml
@@ -5,31 +5,31 @@
     - hetzner-cloud-instantiate
 
 - name: initiate build
-  hosts: my-server
+  hosts: "asz_server"
   remote_user: root
   roles:
     - common
 
 - name: clone sample images
-  hosts: my-server
+  hosts: "asz_server"
   remote_user: root
   roles:
     - clone-sample-images
 
 - name: clone custom images
-  hosts: my-server
+  hosts: "asz_server"
   remote_user: root
   roles:
     - clone-custom-images
 
 - name: prepare osbuild
-  hosts: my-server
+  hosts: "asz_server"
   remote_user: root
   roles:
     - prepare-osbuild
 
 - name: run make
-  hosts: my-server
+  hosts: "asz_server"
   remote_user: root
   roles:
     - run-make

--- a/roles/hetzner-cloud-instantiate/tasks/instantiate_builder.yaml
+++ b/roles/hetzner-cloud-instantiate/tasks/instantiate_builder.yaml
@@ -1,14 +1,16 @@
 ---
 - name: Create a basic server with ssh key
   hcloud_server:
-    name: my-server
+    name: "asz-server-{{ server_id }}"
     server_type: "{{ hcloud_aarch64_server_type if target_arch == 'aarch64' else hcloud_x86_64_server_type }}"
     image: "{{ hcloud_aarch64_image if target_arch == 'aarch64' else hcloud_x86_64_image }}"
     location: "{{ hcloud_aarch64_location if target_arch == 'aarch64' else hcloud_x86_64_location }}"
     ssh_keys: "{{ hcloud_aarch64_ssh_keys if target_arch == 'aarch64' else hcloud_x86_64_ssh_keys }}"
+    labels:
+      asz: "1"
     state: present
 
 - name: Ensure the server is started
   hcloud_server:
-    name: my-server
+    name: "asz-server-{{ server_id }}"
     state: started

--- a/roles/hetzner-cloud-instantiate/tasks/main.yaml
+++ b/roles/hetzner-cloud-instantiate/tasks/main.yaml
@@ -2,14 +2,28 @@
 - name: load variables
   ansible.builtin.include_vars: ../../../config.yaml
 
+# Prepare server id
+- name: prepare random server id
+  ansible.builtin.set_fact:
+    server_id: "{{ lookup('community.general.random_string', length=4, special=false) }}"
+
+- name: debug server id
+  ansible.builtin.debug:
+    msg: "server id: {{ server_id }}"
+
 # Instantiate hetzner server
 - include_tasks: instantiate_builder.yaml 
 
 - meta: refresh_inventory
 
-- name: wait_for_connection
-  wait_for_connection:
+- name: prepare ansible hosts group for playbook usage
+  ansible.builtin.add_host:
+    name: "asz-server-{{ server_id }}"
+    groups: "asz_server"
+
+- name: wait for connection
+  ansible.builtin.wait_for_connection:
     delay: 5
     timeout: 600
-  delegate_to: my-server
+  delegate_to: "asz-server-{{ server_id }}"
   remote_user: root

--- a/roles/hetzner-cloud-teardown/tasks/teardown_builder.yaml
+++ b/roles/hetzner-cloud-teardown/tasks/teardown_builder.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure the server is absent (remove if needed)
+- name: ensure the server is absent (remove if needed)
   hcloud_server:
-    name: my-server
+    name: "asz-server-{{ server_id }}"
     state: absent


### PR DESCRIPTION
Randomise the name of the spawned cloud server so parallel runs do not conflict with each other.