### PR TITLE
roles: add prepare-distro-configs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,24 @@ custom_images_workdir: "{{ ansible_env.HOME }}/zeppelin/custom-images"
 # Leave undefined to clone from sample_images_git_url
 # local_sample_images: "{{ ansible_env.HOME }}/sample-images"
 
+# == Project configurations ==
+distros:
+  - distro_name: cs9
+    extra_var: "Helloworld!"
+  - distro_name: autosd9
+    distro_version: 9
+    distro_baseurl: https://autosd.sig.centos.org/AutoSD-9/nightly/repos/AutoSD/compose/
+    distro_repos:
+      - id: autosd
+        baseurl: $distro_baseurl/AutoSD/$arch/os/
+    distro_devel_repos: []
+    distro_debug_repos:
+      - id: autosd-debug
+        baseurl: $distro_baseurl/AutoSD/$arch/debug/tree/
+    distro_module_id: platform:el9
+    release_rpm: "centos-stream-release"
+    linux_firmware_rpm: "linux-firmware"
+
 # == Advanced configuration ==
 osbuild_vmimages_download_baseurl: "https://autosd.sig.centos.org/AutoSD-9/nightly/osbuildvm-images"
 

--- a/hetzner-cloud.yaml
+++ b/hetzner-cloud.yaml
@@ -22,6 +22,11 @@
   roles:
     - prepare-custom-images
 
+- name: prepare distro configs
+  hosts: localhost
+  roles:
+    - prepare-distro-configs
+
 - name: prepare osbuild
   hosts: "asz_server"
   remote_user: root

--- a/local.yaml
+++ b/local.yaml
@@ -14,6 +14,11 @@
   roles:
     - prepare-custom-images
 
+- name: prepare distro configs
+  hosts: localhost
+  roles:
+    - prepare-distro-configs
+
 - name: prepare osbuild
   hosts: localhost
   roles:

--- a/roles/prepare-distro-configs/tasks/main.yaml
+++ b/roles/prepare-distro-configs/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: load variables
+  ansible.builtin.include_vars: ../../../config.yaml
+
+- include_tasks: prepare_distro_configs.yaml
+  loop: "{{ distros | default([]) }}"

--- a/roles/prepare-distro-configs/tasks/prepare_distro_configs.yaml
+++ b/roles/prepare-distro-configs/tasks/prepare_distro_configs.yaml
@@ -1,0 +1,27 @@
+---
+- name: Preparing distro config file
+  ansible.builtin.debug:
+    var: item
+
+- name: Touch distro config file
+  ansible.builtin.file:
+    path: "{{ sample_images_workdir }}/osbuild-manifests/distro/{{ item.distro_name }}.ipp.yml"
+    state: "touch"
+
+- name: Read existing distro config yaml
+  ansible.builtin.slurp:
+    src: "{{ sample_images_workdir }}/osbuild-manifests/distro/{{ item.distro_name }}.ipp.yml"
+  register: slurped_yaml
+
+- name: Calculate updated distro config yaml
+  ansible.builtin.set_fact:
+    updated_yaml: |
+      {% set old_dict = slurped_yaml.content | b64decode | from_yaml %}
+      {% set new_dict = {"mpp-vars": item, "version": "2"} %}
+      {{ old_dict | ansible.builtin.combine(new_dict, list_merge="append_rp", recursive=true) }}
+
+- name: Write updated distro config yaml
+  ansible.builtin.copy:
+    content: "{{ updated_yaml | to_nice_yaml(indent=2, width=1337) }}"
+    dest: "{{ sample_images_workdir }}/osbuild-manifests/distro/{{ item.distro_name }}.ipp.yml"
+


### PR DESCRIPTION
Enable injecting/updating the distro config files in the sample-images project. Allows defining of a list of dictionaries in config.yaml under the variable "distros", which contain the contents to inject into the distro configs (identified by the variable distro_name).

If the distro config already exists in the sample-images project, the new values defined in config.yaml are merged on top of the existing values.