### PR TITLE
hetzner-cloud.yaml: fix host for prepare-distro-configs

### DIFF
--- a/hetzner-cloud.yaml
+++ b/hetzner-cloud.yaml
@@ -23,7 +23,8 @@
     - prepare-custom-images
 
 - name: prepare distro configs
-  hosts: localhost
+  hosts: "asz_server"
+  remote_user: root
   roles:
     - prepare-distro-configs
 


### PR DESCRIPTION
Delegate this to the remote host, it was accidentally running locally and so not propagating distro configurations to the builder.