### PR TITLE
run-make: support compressing output images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,10 @@ target_image: cs9-qemu-qa-ostree
 target_arch: x86_64
 target_filetype: img
 
+# (optional) Compress resulting system image file with specified compression
+# Leave undefined to have no compression performed
+# target_compression: gz
+
 custom_images_git_url: "https://gitlab.com/redhat/edge/ci-cd/pipe-x/custom-images.git"
 custom_images_git_ref: "main"
 custom_images_workdir: "{{ ansible_env.HOME }}/zeppelin/custom-images"

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,6 +46,20 @@ sample-images Makefile][2].
 
   eg. qcow2
 
+- `target_compression`
+
+  Optionally specifies a compression format for the output image file. This
+  allows for compressing the image immediately after creation to save space
+  and bandwidth when transferring.
+
+  Supported values include:
+    - bz2
+    - gz
+    - xz
+    - zip
+
+  eg. `gz`
+
 - `custom_images_git_url`
 
   Optionally specifies a secondary git repository to clone into the host system

--- a/roles/run-make/tasks/run_make.yaml
+++ b/roles/run-make/tasks/run_make.yaml
@@ -1,6 +1,8 @@
 ---
 - name: decide make params
   set_fact:
+    output_image_basename: "{{ target_image }}.{{ target_arch }}.{{ target_filetype }}"
+    output_image_name: "{{ target_image }}.{{ target_arch }}.{{ target_filetype }}{{ '' if target_compression is undefined else '.'+target_compression }}"
     run_make_params:
       IMAGEDIR: "{{ custom_images_workdir if custom_images_workdir is defined else '' }}"
 
@@ -30,9 +32,18 @@
   when:
      results is failed
 
+- name: compress output (image)
+  community.general.archive:
+    path: "{{ sample_images_workdir }}/osbuild-manifests/{{ output_image_basename }}"
+    dest: "{{ sample_images_workdir }}/osbuild-manifests/{{ output_image_name }}"
+    format: "{{ target_compression }}"
+    remove: true
+  when:
+    target_compression is defined
+
 - name: gather output (image)
   fetch:
-    src: "{{ sample_images_workdir }}/osbuild-manifests/{{ target_image }}.{{ target_arch }}.{{ target_filetype }}"
+    src: "{{ sample_images_workdir }}/osbuild-manifests/{{ output_image_name }}"
     dest: "./out/"
     flat: yes
 


### PR DESCRIPTION
Add new config variable, target_compression. This allows a user to specify that they want the output system image to be compressed. The run-make playbook will then compress the system image before retrieving it back to the Ansible host local file system.