### PR TITLE
prepare-osbuild: fix adding of automotive-sig repo

### DIFF
--- a/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
+++ b/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
@@ -46,6 +46,7 @@
   register: results_copr_abootimg
 
 - name: Add Automotive-SIG repository
+  become: yes
   ansible.builtin.yum_repository:
     name: automotive-sig
     description: Automotive-SIG Repo


### PR DESCRIPTION
This task didn't have the "become" attribute set when adding the automotive-sig repository so on local machines where the Ansible user is not root, this task would fail due to permissions errors.

This commit adds "become: yes" to said task to fix the issue.