### PR TITLE
roles: add run-make-osbuildvm

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,11 @@ custom_images_workdir: "{{ ansible_env.HOME }}/zeppelin/custom-images"
 # Leave undefined to clone from sample_images_git_url
 # local_sample_images: "{{ ansible_env.HOME }}/sample-images"
 
+# (optional) Enable building osbuildvm-images
+# Leave undefined or set to false to disable
+# Resulting VM architecture is based on the build host
+# osbuildvm_images_build: yes
+
 # == Project configurations ==
 distros:
   - distro_name: cs9

--- a/hetzner-cloud.yaml
+++ b/hetzner-cloud.yaml
@@ -40,6 +40,12 @@
   roles:
     - run-make
 
+- name: run make for osbuildvm-images
+  hosts: "asz_server"
+  remote_user: root
+  roles:
+    - run-make-osbuildvm
+
 - name: teardown-builder
   hosts: localhost
   roles:

--- a/local.yaml
+++ b/local.yaml
@@ -28,3 +28,8 @@
   hosts: localhost
   roles:
     - run-make
+
+- name: run make for osbuildvm-images
+  hosts: localhost
+  roles:
+    - run-make-osbuildvm

--- a/roles/run-make-osbuildvm/tasks/main.yaml
+++ b/roles/run-make-osbuildvm/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: load variables
+  ansible.builtin.include_vars: ../../../config.yaml
+
+- include_tasks: run_make_osbuildvm.yaml
+  when: osbuildvm_images_build|default(false)|bool == true

--- a/roles/run-make-osbuildvm/tasks/run_make_osbuildvm.yaml
+++ b/roles/run-make-osbuildvm/tasks/run_make_osbuildvm.yaml
@@ -1,0 +1,44 @@
+---
+- name: run make for osbuildvm-images
+  become: yes
+  make:
+    chdir: "{{ sample_images_workdir }}/osbuild-manifests"
+    target: "osbuildvm-images"
+  ignore_errors: true
+  register: results
+
+- name: Write log files for osbuildvm-images operations
+  copy:
+    content: |
+      chdir: {{ sample_images_workdir }}/osbuild-manifests
+      target: osbuildvm-images
+      {{ results.stdout }}
+    dest: "./out/log.run_make_vmimages.txt"
+  delegate_to: localhost
+
+- name: Error handler
+  debug:
+     var: results
+  failed_when: true
+  when:
+     results is failed
+
+- name: probe results for osbuildvm-images
+  ansible.builtin.find:
+    paths: "{{ sample_images_workdir }}/osbuild-manifests/_build/"
+    recurse: no
+    patterns: ["osbuildvm-*"]
+  register: osbuildvm_images_files
+
+- name: Prepare output directory for osbuildvm-images
+  ansible.builtin.file:
+    path: "./out/osbuildvm-images"
+    state: directory
+  delegate_to: localhost
+
+- name: gather output (osbuildvm-images)
+  ansible.builtin.fetch:
+    src: "{{ item.path }}"
+    dest: "./out/osbuildvm-images/"
+    flat: yes
+  with_items: "{{ osbuildvm_images_files.files }}"

--- a/roles/run-make/tasks/main.yaml
+++ b/roles/run-make/tasks/main.yaml
@@ -3,3 +3,4 @@
   ansible.builtin.include_vars: ../../../config.yaml
 
 - include_tasks: run_make.yaml
+  when: target_image|default(false)|bool == true


### PR DESCRIPTION
Add separate role to build the osbuildvm images. This commit adds the role definitions, the steps to the local and Hetner playbooks, and updates the config.yaml file to support toggling this off and on with a the variable osbuildvm_images_build. The results will be outputted to a subdirectory named osbuildvm-images in the out directory.

This commit also adjusts the run-make role to toggle off if target_image is undefined or set to a falsey value. This is needed to be able to have runs which skip the target image build and only build the osbuildvm images.