### PR TITLE
config.yaml: rename osbuild_vmimages_download_baseurl

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,7 @@ distros:
     linux_firmware_rpm: "linux-firmware"
 
 # == Advanced configuration ==
-osbuild_vmimages_download_baseurl: "https://autosd.sig.centos.org/AutoSD-9/nightly/osbuildvm-images"
+osbuildvm_images_download_baseurl: "https://autosd.sig.centos.org/AutoSD-9/nightly/osbuildvm-images"
 
 osbuild_packages:
   - package: "osbuild"

--- a/docs/config.md
+++ b/docs/config.md
@@ -120,13 +120,13 @@ with running Zeppelin. You should only modify these values when intending to
 force Zeppelin to build with custom resources such as a fork of the
 Automotive-SIG sample-images project.
 
-- `osbuild_vmimages_download_baseurl`
+- `osbuildvm_images_download_baseurl`
 
   This parameter directs where Zeppelin should download the osbuildvm-images
   from. This is needed for cross-arch assembly (eg. building aarch64 images on
   x86_64 hosts).
 
-  More information about osbuild-vmimages can be found [here][4].
+  More information about osbuildvm-images can be found [here][4].
 
 - `osbuild_packages`
 

--- a/roles/common/tasks/init.yaml
+++ b/roles/common/tasks/init.yaml
@@ -10,7 +10,7 @@
     echo "target_arch: {{ target_arch }}"
     echo "target_filetype: {{ target_filetype }}"
     echo "# Advanced Configuration"
-    echo "osbuild_vmimages_download_baseurl: {{ osbuild_vmimages_download_baseurl }}"
+    echo "osbuildvm_images_download_baseurl: {{ osbuildvm_images_download_baseurl }}"
     echo "osbuild_packages: {{ osbuild_packages }}"
     echo "sample_images_git_url: {{ sample_images_git_url }}"
     echo "sample_images_git_ref: {{ sample_images_git_ref }}"

--- a/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
+++ b/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
@@ -77,7 +77,7 @@
 - name: Download osbuildvm-images
   become: yes
   ansible.builtin.get_url:
-    url: "{{ osbuild_vmimages_download_baseurl }}/{{ item }}"
+    url: "{{ osbuildvm_images_download_baseurl }}/{{ item }}"
     dest: "{{ sample_images_build_path }}/{{ item }}"
     mode: 0644
   when: target_arch == "aarch64" and ansible_architecture == "x86_64" and results_build_dir is not failed


### PR DESCRIPTION
Refactor the osbuild_vmimages_download_baseurl variable to be the more correct name osbuildvm_images_download_baseurl. This commit adapts all places where said variable is referenced (incl. docs).