### PR TITLE
run-make: fix toggling on/off

### DIFF
--- a/roles/run-make/tasks/main.yaml
+++ b/roles/run-make/tasks/main.yaml
@@ -3,4 +3,4 @@
   ansible.builtin.include_vars: ../../../config.yaml
 
 - include_tasks: run_make.yaml
-  when: target_image|default(false)|bool == true
+  when: target_image|default("")|length > 0


### PR DESCRIPTION
As part of enabling the osbuildvm-images build feature, a toggle was added to turn off run-make when target_image is undefined/empty. However it was a broken toggle and permanently kept run-make disabled.

This commit fixes the behaviour so it correctly toggles on/off when target_image is undefined/empty vs defined/populated.