### PR TITLE
run-make: fix toggling on/off (2)

### DIFF
--- a/roles/run-make/tasks/main.yaml
+++ b/roles/run-make/tasks/main.yaml
@@ -3,4 +3,4 @@
   ansible.builtin.include_vars: ../../../config.yaml
 
 - include_tasks: run_make.yaml
-  when: target_image|default("")|length > 0
+  when: target_image|default(None)


### PR DESCRIPTION
Try again to fix the toggling on/off (a follow up to e2e8cfc). The fix applied there does not work when target_image is left empty. The role throws the error: 'object of type 'NoneType' has no len()'.

This time, stick to the standard truthfulness testing and skip using length() > 0 to test the variable.