### PR TITLE
prepare_osbuild.yaml: add android-tools as dep

### DIFF
--- a/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
+++ b/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
@@ -58,6 +58,7 @@
 - name: Calculating dependencies
   set_fact:
     osbuild_dependencies:
+      - android-tools
       - abootimg
       - aboot-update
       - make


### PR DESCRIPTION
This is needed to create images with the sparse image format.