### PR TITLE
prepare_osbuild.yaml: add skopeo as a dep

### DIFF
--- a/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
+++ b/roles/prepare-osbuild/tasks/prepare_osbuild.yaml
@@ -65,6 +65,7 @@
       - "{{ osbuild_packages | selectattr('package', 'match', 'osbuild-tools') | map(attribute='value') | first }}"
       - "{{ osbuild_packages | selectattr('package', 'match', 'osbuild-ostree') | map(attribute='value') | first }}"
       - "{{ osbuild_packages | selectattr('package', 'match', 'osbuild-auto') | map(attribute='value') | first }}"
+      - skopeo
 
 - name: Install dependencies
   become: yes


### PR DESCRIPTION
This may be needed by some images that embed containers.