### PR TITLE
config.yaml: add discard_results option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -63,6 +63,11 @@ s3_upload: no
 s3_upload_bucket: "upload-bucket"
 s3_upload_prefix: "upload-prefix"
 
+# Turn off fetching the resulting files
+# Useful if the results were already uploaded by the worker to another location
+# and do not need to be fetched back to the Ansible host
+discard_results: false
+
 # Hetzner Cloud configuration
 hcloud_aarch64_server_type: "cax21"
 hcloud_aarch64_image: "centos-stream-9"

--- a/roles/run-make-osbuildvm/tasks/run_make_osbuildvm.yaml
+++ b/roles/run-make-osbuildvm/tasks/run_make_osbuildvm.yaml
@@ -35,6 +35,7 @@
     path: "./out/osbuildvm-images"
     state: directory
   delegate_to: localhost
+  when: discard_results|default(false)|bool == false
 
 - name: gather output (osbuildvm-images)
   ansible.builtin.fetch:
@@ -42,3 +43,4 @@
     dest: "./out/osbuildvm-images/"
     flat: yes
   with_items: "{{ osbuildvm_images_files.files }}"
+  when: discard_results|default(false)|bool == false

--- a/roles/run-make/tasks/run_make.yaml
+++ b/roles/run-make/tasks/run_make.yaml
@@ -54,15 +54,18 @@
     src: "{{ sample_images_workdir }}/osbuild-manifests/{{ output_image_name }}"
     dest: "./out/"
     flat: yes
+  when: discard_results|default(false)|bool == false
 
 - name: gather output (osbuild json)
   fetch:
     src: "{{ sample_images_build_path }}/{{ target_image }}.{{ target_arch }}.json"
     dest: "./out/"
     flat: yes
+  when: discard_results|default(false)|bool == false
 
 - name: gather output (image manifest)
   fetch:
     src: "{{ sample_images_workdir }}/osbuild-manifests/{{ output_image_basename }}.manifest"
     dest: "./out/"
     flat: yes
+  when: discard_results|default(false)|bool == false


### PR DESCRIPTION
Make it possible to completely discard the results of the make
operations (i.e. do not fetch them to the Ansible host local
filesystem). This is useful if the results were already uploaded by the
build host to another location and are not needed on the Ansible host.