### PR TITLE
config.yaml: default to cs9-qemu-developer-regular

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@
 
 # == Basic configuration ==
 
-target_image: cs9-qemu-qa-ostree
+target_image: cs9-qemu-developer-regular
 target_arch: x86_64
 target_filetype: img
 


### PR DESCRIPTION
Switch from cs9-qemu-qa-ostree to cs9-qemu-developer-regular so we do not depend on the custom-images repository anymore by default.

This also fixes some issues where the qa image isn't building right now.