### PR TITLE
config.yaml: remove the autosd9 distro config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,18 +32,7 @@ distros:
   - distro_name: cs9
     extra_var: "Helloworld!"
   - distro_name: autosd9
-    distro_version: 9
-    distro_baseurl: https://autosd.sig.centos.org/AutoSD-9/nightly/repos/AutoSD/compose/
-    distro_repos:
-      - id: autosd
-        baseurl: $distro_baseurl/AutoSD/$arch/os/
-    distro_devel_repos: []
-    distro_debug_repos:
-      - id: autosd-debug
-        baseurl: $distro_baseurl/AutoSD/$arch/debug/tree/
-    distro_module_id: platform:el9
-    release_rpm: "centos-stream-release"
-    linux_firmware_rpm: "linux-firmware"
+    extra_var: "Helloworld!"
 
 # == Advanced configuration ==
 osbuildvm_images_download_baseurl: "https://autosd.sig.centos.org/AutoSD-9/nightly/osbuildvm-images"


### PR DESCRIPTION
This is available in the sample-images repository these days so we can drop this from here now.