### PR TITLE
aws-ec2-instantiate: request bigger ec2 volumes

### DIFF
--- a/roles/aws-ec2-instantiate/tasks/instantiate_builder.yaml
+++ b/roles/aws-ec2-instantiate/tasks/instantiate_builder.yaml
@@ -19,6 +19,11 @@
     instance_type: "{{ aws_ec2_aarch64_instance_type if target_arch == 'aarch64' else aws_ec2_x86_64_instance_type }}"
     image_id: "{{ aws_ec2_aarch64_ami if target_arch == 'aarch64' else aws_ec2_x86_64_ami }}"
     region: "{{ aws_ec2_aarch64_region if target_arch == 'aarch64' else aws_ec2_x86_64_region }}"
+    volumes:
+      - device_name: /dev/sda1
+        ebs:
+          volume_size: 20
+          delete_on_termination: true
     network:
       assign_public_ip: true
       delete_on_termination: true


### PR DESCRIPTION
Building qcow2 images require more temporary disk space while the image is being copied around than the default 10gb volume attached to an ec2 instance. This changes the default ec2 instance request with a 20gb volume instead.