### PR TITLE
group_vars: set strict host key checking to no for all hosts

### DIFF
--- a/inventories/group_vars/all.yml
+++ b/inventories/group_vars/all.yml
@@ -1,0 +1,4 @@
+---
+
+ansible_ssh_common_args: >-
+  -o StrictHostKeyChecking=no


### PR DESCRIPTION
On some control nodes, ansible.cfg in the project space is not obeyed so try setting StrictHostChecking to no by default in the group_vars for all hosts.

This is needed because ssh'ing to newly instantiated managed nodes with random IPs will trigger typically an unknown host warning that blocks the playbook from completing automatically. With this, that warning is avoided and the playbook can complete.